### PR TITLE
Revert "Bump actions/checkout from 4 to 6"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build Packages
     steps:
       - name: Check out the code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup & Install
         uses: ./.github/composite-actions/install
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest-8
     steps:
       - name: Check out the code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup & Install
         uses: ./.github/composite-actions/install
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest-8
     steps:
       - name: Check out the code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup & Install
         uses: ./.github/composite-actions/install
@@ -107,7 +107,7 @@ jobs:
         bundler: [vite, webpack, esbuild]
     steps:
       - name: Check out the code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup & Install
         uses: ./.github/composite-actions/install
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest-8
     steps:
       - name: Check out the code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup & Install
         uses: ./.github/composite-actions/install

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       - name: Detect package manager
         id: detect-package-manager
         run: |

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           # Do not use the GITHUB_TOKEN by default

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           # Do not use the GITHUB_TOKEN by default

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         
       - name: Install
         uses: ./.github/composite-actions/install


### PR DESCRIPTION
Reverts Dargon789/thirdweb-dev#511

## Summary by Sourcery

Revert the GitHub Actions configuration to use actions/checkout v4 instead of v6 across workflows.

Build:
- Align all workflow checkout steps to actions/checkout v4.2.2 instead of v6.0.1.

CI:
- Update CI, release, CodeQL, Next.js, and Typedoc workflows to use actions/checkout v4.2.2.