### PR TITLE
Revert "Patch 2"

### DIFF
--- a/.changeset/hot-crabs-smash.md
+++ b/.changeset/hot-crabs-smash.md
@@ -1,5 +1,0 @@
----
-"thirdweb": patch
----
-
-Fix: `useWalletBalance` and the `useActiveAccount` to work with `0x{string}` addresses instead of strings.


### PR DESCRIPTION
Reverts Dargon789/thirdweb-dev#560

## Summary by Sourcery

Chores:
- Remove the changeset file associated with the reverted "Patch 2" changes.