### PR TITLE
Potential fix for code scanning alert no. 81: Server-side request forgery

### DIFF
--- a/apps/dashboard/src/app/(app)/api/testnet-faucet/claim/route.ts
+++ b/apps/dashboard/src/app/(app)/api/testnet-faucet/claim/route.ts
@@ -61,7 +61,7 @@ export const POST = async (req: NextRequest) => {
   const { chainId, toAddress, turnstileToken } = requestBody;
   const safeChainId = Number(chainId);
   if (!Number.isFinite(safeChainId) || !Number.isInteger(safeChainId) || safeChainId <= 0) {
-    throw new Error("Invalid chain ID.");
+    return NextResponse.json({ error: "Invalid chain ID." }, { status: 400 });
   }
 
   // Keep outbound Engine path constrained to known supported chains.

--- a/apps/dashboard/src/app/(app)/api/testnet-faucet/claim/route.ts
+++ b/apps/dashboard/src/app/(app)/api/testnet-faucet/claim/route.ts
@@ -56,7 +56,6 @@ export const POST = async (req: NextRequest) => {
       { status: 400 },
     );
   }
-
   const requestBody = (await req.json()) as RequestTestnetFundsPayload;
   const { chainId, toAddress, turnstileToken } = requestBody;
   const safeChainId = Number(chainId);

--- a/apps/dashboard/src/app/(app)/api/testnet-faucet/claim/route.ts
+++ b/apps/dashboard/src/app/(app)/api/testnet-faucet/claim/route.ts
@@ -59,8 +59,15 @@ export const POST = async (req: NextRequest) => {
 
   const requestBody = (await req.json()) as RequestTestnetFundsPayload;
   const { chainId, toAddress, turnstileToken } = requestBody;
-  if (Number.isNaN(chainId)) {
+  const safeChainId = Number(chainId);
+  if (!Number.isFinite(safeChainId) || !Number.isInteger(safeChainId) || safeChainId <= 0) {
     throw new Error("Invalid chain ID.");
+  }
+
+  // Keep outbound Engine path constrained to known supported chains.
+  const amountToClaim = getFaucetClaimAmount(safeChainId);
+  if (amountToClaim === null) {
+    return NextResponse.json({ error: "Faucet not available for this chain." }, { status: 400 });
   }
 
   if (
@@ -224,7 +231,7 @@ export const POST = async (req: NextRequest) => {
       cacheSet(addressCacheKey, "claimed", 24 * 60 * 60),
     ]);
     // then actually transfer the funds
-    const url = `${THIRDWEB_ENGINE_URL}/backend-wallet/${chainId}/transfer`;
+    const url = `${THIRDWEB_ENGINE_URL}/backend-wallet/${safeChainId}/transfer`;
     const response = await fetch(url, {
       body: JSON.stringify({
         amount: amountToClaim,


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/thirdweb-dev/security/code-scanning/81](https://github.com/Dargon789/thirdweb-dev/security/code-scanning/81)

To fix this safely without changing intended functionality, validate and normalize `chainId` **before** using it in the URL, and only allow known supported chain IDs. Then build the URL from the validated value.

Best approach in this file:
1. Parse `chainId` to a number and enforce: finite integer, > 0.
2. Restrict it with an allowlist (derived from `getFaucetClaimAmount` support so behavior stays aligned with existing faucet support).
3. Use the validated numeric value (not raw request value) in the URL.

This should be implemented in `apps/dashboard/src/app/(app)/api/testnet-faucet/claim/route.ts` around:
- the current extraction/validation block near lines 60–64
- the URL construction near line 227

No new dependency is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate and constrain the faucet claim chain ID before constructing the engine transfer URL to address a potential SSRF vector.

Bug Fixes:
- Harden chain ID handling by enforcing numeric, finite, positive integers and rejecting invalid values before using them in requests.
- Prevent faucet calls to unsupported chains by checking the chain ID against existing faucet support and returning a 400 error when unavailable.

Enhancements:
- Use the validated chain ID when building the engine backend-wallet transfer URL to avoid reliance on raw request input.